### PR TITLE
Fix for info being hidden behind the clear and/or submit buttons

### DIFF
--- a/src/sass/_base.scss
+++ b/src/sass/_base.scss
@@ -84,6 +84,12 @@
 	}
 }
 
+@media (min-width: 768px) {
+	.datepicker__info  {
+		max-width: 325px;
+	}
+}
+
 .datepicker__info--feedback {
 	display: none;
 }


### PR DESCRIPTION
This will fix the info (translated or not) not being hidden behind the clear and/or submit buttons.
Smaller screens the button move to below the text already, so there the full width is used like it was before

GIF before change:
![before fix](https://user-images.githubusercontent.com/33500507/183188120-7755d30c-d28c-49c5-af5a-2c82c1a157d8.gif)

GIF after change;
![after fix](https://user-images.githubusercontent.com/33500507/183188375-93b41796-8005-4040-82e5-ee3af6a5d6a1.gif)

Only downside: when the buttons are not enabled, the text will be visible but leave white space:
![image](https://user-images.githubusercontent.com/33500507/183193405-1fad6440-f422-41ee-a078-1115be6b5206.png)
