### PR TITLE
Made the month button arrows unselectable

### DIFF
--- a/src/sass/_base.scss
+++ b/src/sass/_base.scss
@@ -76,6 +76,10 @@
 
 .datepicker__month-button {
 	cursor: pointer;
+    -webkit-user-select: none;    
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
 }
 
 .datepicker__month-button--disabled {


### PR DESCRIPTION
Because when changing months fast, the text/arrows got selected, which a button shouldn't do.

Gif before:
![text selectable on months buttons](https://user-images.githubusercontent.com/33500507/183246124-ff66da52-4b3c-4490-8eee-1a9e797a382d.gif)

Gif After:
![fixed month buttons](https://user-images.githubusercontent.com/33500507/183246123-0c4ddae8-4b92-43d9-8c5f-81b5fab28f3c.gif)
