### PR TITLE
Make specific i18n label changes possible

### DIFF
--- a/src/js/hotel-datepicker.js
+++ b/src/js/hotel-datepicker.js
@@ -52,7 +52,7 @@ export default class HotelDatepicker {
                 ? opts.submitButtonName
                 : "";
         this.closeOnScroll = opts.closeOnScroll || false;
-        this.i18n = opts.i18n || {
+        this.i18n = {
             selected: "Your stay:",
             night: "Night",
             nights: "Nights",
@@ -129,7 +129,7 @@ export default class HotelDatepicker {
             "aria-close-button": "Close the datepicker",
             "aria-clear-button": "Clear the selected dates",
             "aria-submit-button": "Submit the form",
-        };
+        ...opts.i18n };
 
         this.getValue =
             opts.getValue ||


### PR DESCRIPTION
@benitolopez  This change will enable partial changes in the `i18n` object and prioritise labels added in the `config.i18n` 

The problem now is that if, for example, you want to change just a single submit button label on the calendar, that is not possible without copying the whole `i18n` object from the module and then changing that one string in it before passing it as config. 